### PR TITLE
remove cause and place of death

### DIFF
--- a/analysis/study_definition_end.py
+++ b/analysis/study_definition_end.py
@@ -52,32 +52,7 @@ study = StudyDefinition(
             "incidence": 0.05,
         },
     ),
-    cause_of_death = patients.died_from_any_cause(
-            on_or_before="index_date",
-            returning="underlying_cause_of_death",
-            return_expectations={
-                "category": {
-                    "ratios": {
-                        "code1": 0.5,
-                        "code2": 0.5,
-                    }
-                }
-            },
-            
-        ),
-    place_of_death = patients.died_from_any_cause(
-            on_or_before="index_date",
-            returning="place_of_death",
-            return_expectations={
-                "category": {
-                    "ratios": {
-                        "code1": 0.5,
-                        "code2": 0.5,
-                    }
-                }
-            },
-        ),
-
+    
     # Ethnicity
     ethnicity_opensafely=patients.with_these_clinical_events(
         ethnicity_opensafely,


### PR DESCRIPTION
These are not currently supported in the [EMIS backend](https://github.com/opensafely-core/cohort-extractor/blob/9da8873acbc473f16e536cb241fdadb6e98a0e8e/cohortextractor/emis_backend.py#L1276-L1281).