### PR TITLE
Reinstate ONS deaths

### DIFF
--- a/analysis/study_definition_end.py
+++ b/analysis/study_definition_end.py
@@ -22,15 +22,47 @@ study = StudyDefinition(
         returning="date_of_death",
         date_format="YYYY-MM-DD",
         return_expectations={
-            "date": {"earliest" : "2020-02-01"},
-            "rate" : "exponential_increase"
+            "date": {"earliest": "2020-02-01"},
+            "rate": "exponential_increase",
         },
     ),
     died_any_pc=patients.with_death_recorded_in_primary_care(
         on_or_before="index_date",
         returning="binary_flag",
     ),
-   
+
+    died_any=patients.died_from_any_cause(
+        on_or_before="index_date",
+        returning="binary_flag",
+        return_expectations={"incidence": 0.05},
+    ),
+    died_any_date=patients.died_from_any_cause(
+        on_or_before="index_date",
+        returning="date_of_death",
+        date_format="YYYY-MM-DD",
+        return_expectations={
+            "date": {"earliest": "2020-02-01"},
+            "rate": "exponential_increase",
+        },
+    ),
+    covid_related_death=patients.with_these_codes_on_death_certificate(
+        covid_death_codelist,
+        returning="binary_flag",
+        on_or_before="index_date",
+        match_only_underlying_cause=False,
+        return_expectations={
+            "incidence": 0.05,
+        },
+    ),
+    covid_related_death_date=patients.with_these_codes_on_death_certificate(
+        covid_death_codelist,
+        returning="date_of_death",
+        on_or_before="index_date",
+        match_only_underlying_cause=False,
+        date_format="YYYY-MM-DD",
+        return_expectations={
+            "date": {"earliest": "index_date", "latest": "today"},
+        },
+    ),
     **vaccination_variables,
-    
 )

--- a/analysis/study_definition_end_2022.py
+++ b/analysis/study_definition_end_2022.py
@@ -1,0 +1,35 @@
+from cohortextractor import (
+    StudyDefinition,
+    patients,
+)
+
+from codelists import *
+from variables.vaccination_variables import vaccination_variables
+
+end_date = "2022-06-30"
+
+
+study = StudyDefinition(
+    default_expectations={
+        "date": {"earliest": "1900-01-01", "latest": "today"},
+        "rate": "uniform",
+        "incidence": 0.8,
+    },
+    index_date=end_date,
+    population=patients.all(),
+    died_any_date_pc=patients.with_death_recorded_in_primary_care(
+        on_or_before="index_date",
+        returning="date_of_death",
+        date_format="YYYY-MM-DD",
+        return_expectations={
+            "date": {"earliest": "2020-02-01"},
+            "rate": "exponential_increase",
+        },
+    ),
+    died_any_pc=patients.with_death_recorded_in_primary_care(
+        on_or_before="index_date",
+        returning="binary_flag",
+    ),
+    
+    **vaccination_variables,
+)

--- a/project.yaml
+++ b/project.yaml
@@ -1483,6 +1483,12 @@ actions:
       highly_sensitive:
         cohort: output/input_end.csv
 
+  generate_study_population_end_2022:
+    run: cohortextractor:latest generate_cohort --study-definition study_definition_end_2022 --output-format=csv --with-end-date-fix
+    outputs:
+      highly_sensitive:
+        cohort: output/input_end_2022.csv
+
   generate_study_population_eth:
     run: cohortextractor:latest generate_cohort --study-definition study_definition_ethnicity --output-format=csv --with-end-date-fix
     outputs:


### PR DESCRIPTION
reinstates ONS death variables into the end study def (until Jul 21) and extracts primary care deaths until the Jul 22